### PR TITLE
Fix/isomorphism dictionary logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,13 @@ __pycache__/
 
 # Unit test / coverage reports
 .cache
+.pytest_cache/
 
 # mypy
 .mypy_cache/
+
+# virtual environment
+venv/
+
+# IDE
+.vscode/

--- a/examples/isomorph.py
+++ b/examples/isomorph.py
@@ -221,10 +221,21 @@ def get_translation_dict(flop):
     True
     """
     flop = sorted(flop)
-    suit1, suit2, suit3 = [card.suit for card in flop]
+    suits = [card.suit for card in flop]
+    suit1, suit2, suit3 = suits
+    suit_counts = {suit: suits.count(suit) for suit in suits}
+    suit_max = max(suit_counts, key=suit_counts.get)
+    suit_min = min(suit_counts, key=suit_counts.get)
 
     canonical_flop = get_canonical(flop)
-    canon1, canon2, canon3 = [card.suit for card in canonical_flop]
+    canons = sorted([card.suit for card in canonical_flop])
+    canon1, canon2, canon3 = canons
+    canon_counts = {suit: canons.count(suit) for suit in canons}
+    canon_max = max(canon_counts, key=canon_counts.get)
+    canon_min = min(canon_counts, key=canon_counts.get)
+
+    values = sorted(canon_counts.values())
+    partition = values + [0] * (3 - len(values))
 
     # if the flop matches the canonical version, no translation necessary
     if (suit1, suit2, suit3) == (canon1, canon2, canon3):
@@ -239,48 +250,27 @@ def get_translation_dict(flop):
     canonical_unused = sorted(list(canonical_unused))
     both_unused = sorted(list(both_unused))
 
-    if suit1 == suit2 == suit3:
-        # suit pattern is 'AAA'
+    # canonical forms are zero-trailing 3-part weak compositions
+    if partition == [3, 0, 0]:
         return {
-            suit1: canon1,                   # The first flop suit and the
-            canon1: suit1,                   # first canon suit must switch.
-            both_unused[0]: both_unused[0],  # The remaining two suits
-            both_unused[1]: both_unused[1],  # don't matter
+            suit1: canon1,
+            canon1: suit1,
+            both_unused[0]: both_unused[0],
+            both_unused[1]: both_unused[1],
         }
-
-    elif suit1 == suit2 != suit3:
-        # suit pattern is 'AAB'
+    elif partition in [[2, 1, 0], [1, 2, 0]]:
         return {
-            suit1: canon1,                   # suit of 1st card = 1st canon
-            suit3: canon3,                   # suit of 3rd card = 3rd canon
-            unused[0]: canonical_unused[0],  # Must be the remaining two
-            unused[1]: canonical_unused[1],  # suits of each set
+            suit_max: canon_max,
+            suit_min: canon_min,
+            unused[0]: canonical_unused[0],
+            unused[1]: canonical_unused[1],
         }
-
-    elif suit1 != suit2 == suit3:
-        # suit pattern is 'ABB'
+    elif partition == [1, 1, 1]:
         return {
-            suit1: canon1,                   # suit of 1st card = 1st canon
-            suit2: canon2,                   # suit of 2nd card = 2nd canon
-            unused[0]: canonical_unused[0],  # Must be the remaining two
-            unused[1]: canonical_unused[1],  # suits of each set
+            suit1: canon1,
+            suit2: canon2,
+            suit3: canon3,
+            unused[0]: canonical_unused[0],
         }
-
-    # Note the order of cards
-    elif suit1 == suit3 != suit2:
-        # suit pattern is 'ABA'
-        return {
-            suit1: canon1,                   # suit of 1st card = 1st canon
-            suit2: canon2,                   # suit of 2nd card = 2nd canon
-            unused[0]: canonical_unused[0],  # Must be the remaining two
-            unused[1]: canonical_unused[1],  # suits of each set
-        }
-
-    elif suit1 != suit2 != suit3:
-        # suit pattern is 'ABC'
-        return {
-            suit1: canon1,                   # suit of 1st card = 1st canon
-            suit2: canon2,                   # suit of 2nd card = 2nd canon
-            suit3: canon3,                   # suit of 3rd card = 3rd canon
-            unused[0]: canonical_unused[0],  # The remaining suits.
-        }
+    else:
+        raise ValueError(f"{flop=}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,27 +15,27 @@ jupyter==1.0.0
 jupyter-client==5.1.0
 jupyter-console==5.2.0
 jupyter-core==4.3.0
-MarkupSafe==1.0
+# MarkupSafe==1.0
 mccabe==0.6.1
 mistune==0.7.4
 nbconvert==5.3.0
 nbformat==4.4.0
 notebook==5.0.0
-numpy==1.13.1
-pandas==0.20.3
+# numpy==1.13.1
+# pandas==0.20.3
 pandocfilters==1.4.2
 pexpect==4.2.1
 pickleshare==0.7.4
 prompt-toolkit==1.0.15
 ptyprocess==0.5.2
-py==1.4.34
+py>=1.4.34
 pycodestyle==2.3.1
 pyflakes==1.5.0
 Pygments==2.2.0
-pytest==3.2.1
+pytest>=3.2.1
 python-dateutil==2.6.1
 pytz==2017.2
-pyzmq==16.0.2
+# pyzmq==16.0.2
 qtconsole==4.3.1
 simplegeneric==0.8.1
 six==1.10.0

--- a/tests/test_isomorph.py
+++ b/tests/test_isomorph.py
@@ -1,16 +1,31 @@
-from examples.isomorph import (
-    get_all_canonicals,
-    get_canonical,
-    get_translation_dict,
-)
-from pokertools import cards_from_str as flop
+import pytest
+
+from examples.isomorph import get_all_canonicals, get_canonical, get_translation_dict
+from pokertools import cards_from_str as cards
 
 
-def test_isomorph():
+def test_get_all_canonicals():
     assert len(get_all_canonicals()) == 1755
 
-    assert get_canonical(flop('6s 8d 7c')) == flop('6c 7d 8h')
-    assert get_translation_dict(flop('6s 8d 7c')) == {'c': 'd', 'd': 'h', 'h': 's', 's': 'c'}
+@pytest.mark.parametrize(
+    "flop, expected_result",
+    [
+        (('6s 8d 7c'), ('6c 7d 8h')),
+        (('Qs Qd 4d'), ('4c Qc Qd')),
+        (('Qs Ts Tc'), ('Tc Td Qc')), # ABB -> ABA
+    ]
+)
+def test_get_canonical(flop, expected_result):
+    assert get_canonical(cards(flop)) == cards(expected_result)
 
-    assert get_canonical(flop('Qs Qd 4d')) == flop('4c Qc Qd')
-    assert get_translation_dict(flop('Qs Qd 4d')) == {'c': 'h', 'd': 'c', 'h': 's', 's': 'd'}
+
+@pytest.mark.parametrize(
+    "flop, expected_result",
+    [
+        (('6s 8d 7c'), {'c': 'd', 'd': 'h', 'h': 's', 's': 'c'}),
+        (('Qs Qd 4d'), {'c': 'h', 'd': 'c', 'h': 's', 's': 'd'}),
+        (('Qs Ts Tc'), {'c': 'd', 'd': 'h', 'h': 's', 's': 'c'}),
+    ]
+)
+def test_get_translation_dict(flop, expected_result):
+    assert get_translation_dict(cards(flop)) == expected_result


### PR DESCRIPTION
This pull request fixes a bug in get_translation_dict() where it returns incorrect mappings for certain flop patterns, specifically when handling flops like 'Qs Ts Tc'. The issue occurs when a noncanonical flop follows an ABB pattern (like c,s,s when sorted) but its canonical form follows an ABA ('Tc Td Qc') pattern.

To demonstrate the bug, I've added a test case:

```
@pytest.mark.parametrize(
    "flop, expected_result",
    [
        # pre-existing tests here
        (('Qs Ts Tc'), {'c': 'd', 'd': 'h', 'h': 's', 's': 'c'}),
    ]
)
def test_get_translation_dict(flop, expected_result):
    assert get_translation_dict(cards(flop)) == expected_result
```
The original implementation attempted to derive the translation dictionary by analyzing patterns in the input flop (the noncanonical form). This approach led to errors because the input pattern doesn't always match the canonical pattern. This fix reorients the logic to work off the specific structure of canonical flops: they are zero-trailing 3-part weak compositions. This means the suits of a canonical flop can be represented as:

- exactly 3 nonnegative integers that sum to 3
- zeroes occur only to the right of any positive values

Additionally, I've modernized the testing framework by migrating to pytest and I've updated requirements.txt to ensure compatibility with current Python versions.